### PR TITLE
Add autoindent check control to MessageForm #195 (#367)

### DIFF
--- a/App.config
+++ b/App.config
@@ -90,7 +90,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/src/ServiceBusExplorer/Forms/MessageForm.Designer.cs
+++ b/src/ServiceBusExplorer/Forms/MessageForm.Designer.cs
@@ -60,6 +60,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             this.messagesSplitContainer = new System.Windows.Forms.SplitContainer();
             this.messageListTextPropertiesSplitContainer = new System.Windows.Forms.SplitContainer();
             this.grouperMessageText = new Microsoft.Azure.ServiceBusExplorer.Controls.Grouper();
+            this.chkAutoindent = new System.Windows.Forms.CheckBox();
             this.txtMessageText = new FastColoredTextBoxNS.FastColoredTextBox();
             this.grouperMessageCustomProperties = new Microsoft.Azure.ServiceBusExplorer.Controls.Grouper();
             this.propertiesDataGridView = new System.Windows.Forms.DataGridView();
@@ -168,6 +169,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             this.grouperMessageText.BackgroundGradientMode = Microsoft.Azure.ServiceBusExplorer.Controls.Grouper.GroupBoxGradientMode.None;
             this.grouperMessageText.BorderColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.grouperMessageText.BorderThickness = 1F;
+            this.grouperMessageText.Controls.Add(this.chkAutoindent);
             this.grouperMessageText.Controls.Add(this.txtMessageText);
             this.grouperMessageText.CustomGroupBoxColor = System.Drawing.Color.FromArgb(((int)(((byte)(153)))), ((int)(((byte)(180)))), ((int)(((byte)(209)))));
             this.grouperMessageText.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -185,6 +187,23 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             this.grouperMessageText.ShadowThickness = 1;
             this.grouperMessageText.Size = new System.Drawing.Size(666, 225);
             this.grouperMessageText.TabIndex = 26;
+            // 
+            // chkAutoindent
+            // 
+            this.chkAutoindent.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.chkAutoindent.AutoSize = true;
+            this.chkAutoindent.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(215)))), ((int)(((byte)(228)))), ((int)(((byte)(242)))));
+            this.chkAutoindent.Checked = true;
+            this.chkAutoindent.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.chkAutoindent.ForeColor = System.Drawing.Color.Black;
+            this.chkAutoindent.Location = new System.Drawing.Point(530, 3);
+            this.chkAutoindent.Name = "chkAutoindent";
+            this.chkAutoindent.Padding = new System.Windows.Forms.Padding(18, 0, 9, 0);
+            this.chkAutoindent.Size = new System.Drawing.Size(104, 17);
+            this.chkAutoindent.TabIndex = 155;
+            this.chkAutoindent.Text = "Autoindent";
+            this.chkAutoindent.UseVisualStyleBackColor = false;
+            this.chkAutoindent.CheckedChanged += new System.EventHandler(this.ChkAutoindent_CheckedChanged);
             // 
             // txtMessageText
             // 
@@ -209,6 +228,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             this.txtMessageText.CharWidth = 8;
             this.txtMessageText.Cursor = System.Windows.Forms.Cursors.IBeam;
             this.txtMessageText.DisabledColor = System.Drawing.Color.FromArgb(((int)(((byte)(100)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))), ((int)(((byte)(180)))));
+            this.txtMessageText.Font = new System.Drawing.Font("Courier New", 9.75F);
             this.txtMessageText.ForeColor = System.Drawing.SystemColors.ControlText;
             this.txtMessageText.IsReplaceMode = false;
             this.txtMessageText.Location = new System.Drawing.Point(16, 32);
@@ -334,7 +354,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             // 
             // cboSenderInspector
             // 
-            this.cboSenderInspector.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
+            this.cboSenderInspector.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.cboSenderInspector.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboSenderInspector.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
@@ -424,6 +444,7 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             ((System.ComponentModel.ISupportInitialize)(this.messageListTextPropertiesSplitContainer)).EndInit();
             this.messageListTextPropertiesSplitContainer.ResumeLayout(false);
             this.grouperMessageText.ResumeLayout(false);
+            this.grouperMessageText.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.txtMessageText)).EndInit();
             this.grouperMessageCustomProperties.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.propertiesDataGridView)).EndInit();
@@ -453,5 +474,6 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
         private System.Windows.Forms.CheckBox chkNewMessageId;
         private System.Windows.Forms.CheckBox chkRemove;
         private FastColoredTextBoxNS.FastColoredTextBox txtMessageText;
+        private System.Windows.Forms.CheckBox chkAutoindent;
     }
 }

--- a/src/ServiceBusExplorer/Forms/MessageForm.cs
+++ b/src/ServiceBusExplorer/Forms/MessageForm.cs
@@ -110,26 +110,9 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             InitializeComponent();
 
             cboBodyType.SelectedIndex = (int)MainForm.SingletonMainForm.MessageBodyType;
-
             messagePropertyGrid.SelectedObject = brokeredMessage;
 
-            var messageText = serviceBusHelper.GetMessageText(brokeredMessage, out _);
-
-            if (JsonSerializerHelper.IsJson(messageText))
-            {
-                txtMessageText.Language = Language.JSON;
-                txtMessageText.Text = JsonSerializerHelper.Indent(messageText);
-            }
-            else if (XmlHelper.IsXml(messageText))
-            {
-                txtMessageText.Language = Language.HTML;
-                txtMessageText.Text = XmlHelper.Indent(messageText);
-            }
-            else
-            {
-                txtMessageText.Language = Language.Custom;
-                txtMessageText.Text = messageText;
-            }
+            InitializeMessageTextControl(brokeredMessage);
 
             // Initialize the DataGridView.
             bindingSource.DataSource = new BindingList<MessagePropertyInfo>(brokeredMessage.Properties.Select(p => new MessagePropertyInfo(p.Key,
@@ -652,7 +635,14 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
         {
             e.Cancel = true;
         }
+
+        void ChkAutoindent_CheckedChanged(object sender, EventArgs e)
+        {
+            InitializeMessageTextControl(messagePropertyGrid.SelectedObject as BrokeredMessage);
+        }
         #endregion
+
+        #region Private Methods
 
         string GetShortValueTypeName(object o)
         {
@@ -660,5 +650,28 @@ namespace Microsoft.Azure.ServiceBusExplorer.Forms
             var typeName = o.GetType().ToString();
             return typeName.Length > 7 ? typeName.Substring(7) : typeName;
         }
+
+        void InitializeMessageTextControl(BrokeredMessage message)
+        {
+            var messageText = this.serviceBusHelper.GetMessageText(message, out _);
+
+            if (chkAutoindent.Checked && JsonSerializerHelper.IsJson(messageText))
+            {
+                txtMessageText.Language = Language.JSON;
+                txtMessageText.Text = JsonSerializerHelper.Indent(messageText);
+            }
+            else if (chkAutoindent.Checked && XmlHelper.IsXml(messageText))
+            {
+                txtMessageText.Language = Language.HTML;
+                txtMessageText.Text = XmlHelper.Indent(messageText);
+            }
+            else
+            {
+                txtMessageText.Language = Language.Custom;
+                txtMessageText.Text = messageText;
+            }
+        }
+
+        #endregion
     }
 }

--- a/src/ServiceBusExplorer/ServiceBusExplorer.csproj
+++ b/src/ServiceBusExplorer/ServiceBusExplorer.csproj
@@ -672,7 +672,7 @@
     <PackageReference Include="Microsoft.Azure.NotificationHubs" Version="2.16.0.234" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.0.3" />
     <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" Version="3.2.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.2.4" />
     <PackageReference Include="WindowsAzure.ServiceBus" Version="5.2.0" />
   </ItemGroup>


### PR DESCRIPTION
* Update WindowsAzure.ServiceBus to v5.2.0.

* Add autoindent check control to MessageForm.

* Allow resubmit a message with the same body it was received.
* Avoid copying original custom properties when resubmitting if not desired.

* Add "from sequence number" text box to ReceiveModelForm.

* Allow picking messages from a given sequence number.

* Minor naming fixes in ReceiveModelForm and HandleQueueControl

* Rename SequenceNumber by FromSequenceNumber in ReceiveModelForm.
* Set fromSequenceNumber as an optional parameter in HandleQueueControl.

* Revert "Add autoindent check control to MessageForm."

This reverts commit e5f146cf7bd3b95cf434765b19d2e660734d0070.

* Update Newtonsoft.Json library to 12.0.2

* Add autoindent check control to MessageForm. #195

* Allow resubmit a message with the same body it was received, without adding extra chars.